### PR TITLE
Test case for issue 19

### DIFF
--- a/src/move.test.js
+++ b/src/move.test.js
@@ -433,6 +433,64 @@ describe('move', () => {
     })
   })
 
+  it('should move fields with different shapes', () => {
+    // implementation of changeValue taken directly from Final Form
+    const changeValue = (state, name, mutate) => {
+      const before = getIn(state.formState.values, name)
+      const after = mutate(before)
+      state.formState.values = setIn(state.formState.values, name, after) || {}
+    }
+    const state = {
+      formState: {
+        values: {
+          foo: [{ dog: 'apple dog', cat: 'apple cat' }, { dog: 'banana dog' }]
+        }
+      },
+      fields: {
+        'foo[0].dog': {
+          name: 'foo[0].dog',
+          touched: true,
+          error: 'Error A Dog'
+        },
+        'foo[0].cat': {
+          name: 'foo[0].cat',
+          touched: false,
+          error: 'Error A Cat'
+        },
+        'foo[1].dog': {
+          name: 'foo[1].dog',
+          touched: true,
+          error: 'Error B Dog'
+        }
+      }
+    }
+    move(['foo', 0, 1], state, { changeValue })
+    expect(state).toEqual({
+      formState: {
+        values: {
+          foo: [{ dog: 'banana dog' }, { dog: 'apple dog', cat: 'apple cat' }]
+        }
+      },
+      fields: {
+        'foo[0].dog': {
+          name: 'foo[0].dog',
+          touched: true,
+          error: 'Error B Dog'
+        },
+        'foo[1].dog': {
+          name: 'foo[1].dog',
+          touched: true,
+          error: 'Error A Dog'
+        },
+        'foo[1].cat': {
+          name: 'foo[1].cat',
+          touched: false,
+          error: 'Error A Cat'
+        }
+      }
+    })
+  })
+
   it('should preserve functions in field state', () => {
     // implementation of changeValue taken directly from Final Form
     const changeValue = (state, name, mutate) => {


### PR DESCRIPTION
Hi, @erikras! 

Sorry for directly mentioning you, but I need your help!
I opened issue https://github.com/final-form/final-form-arrays/issues/19 some time ago, and since there were no activities, I tried to handle it myself.

It turns out that the bug occurs due to `moveFieldState` function, which expects that objects in the array have the same shape. It's not always true. I wrote a test for this case.

```js
function moveFieldState({ destKey, source }) {
  state.fields[destKey] = {
    ...source,
    name: destKey,
    change: state.fields[destKey].change, // prevent functions from being overwritten
    blur: state.fields[destKey].blur,
    focus: state.fields[destKey].focus,
    lastFieldState: undefined // clearing lastFieldState forces renotification
  }
}
```

I will be glad to make a fix, but I not sure what to do with these `change`, `blur` and `focus` handlers in case if there is no `state.fields[destKey]` field.
Could you tell the right way to handle this?