### PR TITLE
fix: flow libdefs file naming

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -57,7 +57,15 @@ module.exports = {
       description: 'Generates table of contents in README',
       script: 'doctoc README.md'
     },
-    copyTypes: npsUtils.copy('src/*.js.flow src/*.d.ts dist'),
+    copyTypes: series(
+      npsUtils.copy('src/*.js.flow src/*.d.ts dist'),
+      npsUtils.copy(
+        'dist/index.js.flow dist --rename="final-form-arrays.cjs.js.flow"'
+      ),
+      npsUtils.copy(
+        'dist/index.js.flow dist --rename="final-form-arrays.es.js.flow"'
+      )
+    ),
     lint: {
       description: 'lint the entire project',
       script: 'eslint .'


### PR DESCRIPTION
Currently, Flow is unable to pick bundled library definitions, since it can't match `index.js.flow` with `final-form-arrays.cjs.js` or `final-form-arrays.es.js`. So I borrowed build configuration from `final-form` repo https://github.com/final-form/final-form/blob/master/package-scripts.js#L58-L64 to resolve the issue

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form Arrays!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form-arrays/blob/master/.github/CONTRIBUTING.md

-->
