### PR TITLE
fix(moveFieldState): get change/blur/focus callbacks from oldState

### DIFF
--- a/src/moveFieldState.js
+++ b/src/moveFieldState.js
@@ -14,19 +14,19 @@ function moveFieldState(
     // prevent functions from being overwritten
     // if the state.fields[destKey] does not exist, it will be created
     // when that field gets registered, with its own change/blur/focus callbacks
-    change: oldState.fields[destKey] && oldState.fields[destKey].change,
-    blur: oldState.fields[destKey] && oldState.fields[destKey].blur,
-    focus: oldState.fields[destKey] && oldState.fields[destKey].focus,
+    change: oldState.fields[source.name] && oldState.fields[source.name].change,
+    blur: oldState.fields[source.name] && oldState.fields[source.name].blur,
+    focus: oldState.fields[source.name] && oldState.fields[source.name].focus,
     lastFieldState: undefined // clearing lastFieldState forces renotification
   }
   if (!state.fields[destKey].change) {
-    delete state.fields[destKey].change;
+    delete state.fields[destKey].change
   }
   if (!state.fields[destKey].blur) {
-    delete state.fields[destKey].blur;
+    delete state.fields[destKey].blur
   }
   if (!state.fields[destKey].focus) {
-    delete state.fields[destKey].focus;
+    delete state.fields[destKey].focus
   }
 }
 

--- a/src/remove.test.js
+++ b/src/remove.test.js
@@ -137,18 +137,18 @@ describe('remove', () => {
         },
         'foo[1]': {
           name: 'foo[1]',
-          blur: blur1,
-          change: change1,
-          focus: focus1,
+          blur: blur2,
+          change: change2,
+          focus: focus2,
           touched: true,
           error: 'C Error',
           lastFieldState: undefined
         },
         'foo[2]': {
           name: 'foo[2]',
-          blur: blur2,
-          change: change2,
-          focus: focus2,
+          blur: blur3,
+          change: change3,
+          focus: focus3,
           touched: false,
           error: 'D Error',
           lastFieldState: undefined
@@ -160,7 +160,6 @@ describe('remove', () => {
       }
     })
   })
-  
 
   it('should remove value from the specified index, and return it (nested arrays)', () => {
     const array = ['a', 'b', 'c', 'd']
@@ -249,18 +248,18 @@ describe('remove', () => {
         },
         'foo[0][1]': {
           name: 'foo[0][1]',
-          blur: blur1,
-          change: change1,
-          focus: focus1,
+          blur: blur2,
+          change: change2,
+          focus: focus2,
           touched: true,
           error: 'C Error',
           lastFieldState: undefined
         },
         'foo[0][2]': {
           name: 'foo[0][2]',
-          blur: blur2,
-          change: change2,
-          focus: focus2,
+          blur: blur3,
+          change: change3,
+          focus: focus3,
           touched: false,
           error: 'D Error',
           lastFieldState: undefined
@@ -271,7 +270,7 @@ describe('remove', () => {
         }
       }
     })
-  })  
+  })
 
   it('should remove value from the specified index, and handle new fields', () => {
     const array = ['a', { key: 'val' }]

--- a/src/removeBatch.test.js
+++ b/src/removeBatch.test.js
@@ -170,9 +170,9 @@ describe('removeBatch', () => {
       fields: {
         'foo[0]': {
           name: 'foo[0]',
-          blur: blur0,
-          change: change0,
-          focus: focus0,
+          blur: blur1,
+          change: change1,
+          focus: focus1,
           touched: false,
           error: 'Second Error',
           lastFieldState: undefined
@@ -307,18 +307,18 @@ describe('removeBatch', () => {
         },
         'foo[1]': {
           name: 'foo[1]',
-          blur: blur1,
-          change: change1,
-          focus: focus1,
+          blur: blur3,
+          change: change3,
+          focus: focus3,
           touched: false,
           error: 'D Error',
           lastFieldState: undefined
         },
         'foo[2]': {
           name: 'foo[2]',
-          blur: blur2,
-          change: change2,
-          focus: focus2,
+          blur: blur4,
+          change: change4,
+          focus: focus4,
           touched: true,
           error: 'E Error',
           lastFieldState: undefined
@@ -432,18 +432,18 @@ describe('removeBatch', () => {
         },
         'foo[0][1]': {
           name: 'foo[0][1]',
-          blur: blur1,
-          change: change1,
-          focus: focus1,
+          blur: blur3,
+          change: change3,
+          focus: focus3,
           touched: false,
           error: 'D Error',
           lastFieldState: undefined
         },
         'foo[0][2]': {
           name: 'foo[0][2]',
-          blur: blur2,
-          change: change2,
-          focus: focus2,
+          blur: blur4,
+          change: change4,
+          focus: focus4,
           touched: true,
           error: 'E Error',
           lastFieldState: undefined

--- a/src/swap.js
+++ b/src/swap.js
@@ -1,8 +1,7 @@
 // @flow
 import type { MutableState, Mutator, Tools } from 'final-form'
-import moveFieldState from './moveFieldState'
-import moveFields from './moveFields';
-import restoreFunctions from './restoreFunctions';
+import moveFields from './moveFields'
+import restoreFunctions from './restoreFunctions'
 
 const TMP: string = 'tmp'
 


### PR DESCRIPTION
Previously in function moveFieldState callbacks "change/blur/focus"  is requested by new destKey. But it will be more correct to save previous callbacks. For example, when I remove second value from array I will expect it will also remove second callback with it. So I tuned a bit tests for remove cases. It should fix issues #49 #51.

What do you think about this changes?
