### PR TITLE
Fixed bug with deleting rows with validators

### DIFF
--- a/src/moveFieldState.js
+++ b/src/moveFieldState.js
@@ -17,16 +17,19 @@ function moveFieldState(
     change: oldState.fields[destKey] && oldState.fields[destKey].change,
     blur: oldState.fields[destKey] && oldState.fields[destKey].blur,
     focus: oldState.fields[destKey] && oldState.fields[destKey].focus,
+    validators: oldState.fields[destKey] && oldState.fields[destKey].validators,
+    validateFields:
+      oldState.fields[destKey] && oldState.fields[destKey].validateFields,
     lastFieldState: undefined // clearing lastFieldState forces renotification
   }
   if (!state.fields[destKey].change) {
-    delete state.fields[destKey].change;
+    delete state.fields[destKey].change
   }
   if (!state.fields[destKey].blur) {
-    delete state.fields[destKey].blur;
+    delete state.fields[destKey].blur
   }
   if (!state.fields[destKey].focus) {
-    delete state.fields[destKey].focus;
+    delete state.fields[destKey].focus
   }
 }
 


### PR DESCRIPTION
Consider the following situation:

1. Lets say initially you have 1 row in the form array.
2. Add one new row to the form.
3. Delete the first one (now you are in trouble if you have validators).

Problems:
1. If you have attached validator to the field, your validator is not updated to point to the validator on index 0! So if you pass additional data to the validator (like index for example), the index is not updated!
2. If you have attached  validateFields to the field to optimize the validator calls - (BOOM), you receive an error.

Check out the following example for more details. Try the firstName field and watch the console:
https://codesandbox.io/s/array-fields-forked-lb9v0?file=/src/App.js