### PR TITLE
Fix #97: Use numeric sort in removeBatch

### DIFF
--- a/src/removeBatch.lexicographic-bug.test.ts
+++ b/src/removeBatch.lexicographic-bug.test.ts
@@ -1,0 +1,62 @@
+import removeBatch from './removeBatch'
+import { getIn, setIn, MutableState } from 'final-form'
+import { createMockTools } from './testUtils'
+
+describe('removeBatch lexicographic sorting bug', () => {
+  it('should remove correct items when indexes > 9 (numeric vs lexicographic sort)', () => {
+    const changeValue = jest.fn((state: any, name: string, mutate: (value: any) => any) => {
+      const before = getIn(state.formState.values, name)
+      const after = mutate(before)
+      state.formState.values = setIn(state.formState.values, name, after) || {} as any
+    })
+
+    // Create 20 items
+    const items = Array.from({ length: 20 }, (_, i) => ({ id: i + 1 }))
+    const fields: any = {}
+    items.forEach((_, i) => {
+      fields[`customers[${i}]`] = { name: `customers[${i}]` }
+    })
+
+    const state: MutableState<any> = {
+      formState: { values: { customers: items } as any },
+      fields
+    }
+
+    // Remove indexes 4-16 (customers with id 5-17)
+    // Without numeric sort: lexicographic [10,11,12,13,14,15,16,4,5,6,7,8,9] - removes WRONG items
+    // With numeric sort: [4,5,6,7,8,9,10,11,12,13,14,15,16] - removes correct items
+    removeBatch(['customers', [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]], state, createMockTools({ changeValue }))
+
+    const customers = state.formState.values.customers
+
+    // Should keep customers with id 1-4 and 18-20
+    expect(customers).toHaveLength(7)
+    expect(customers.map(c => c.id)).toEqual([1, 2, 3, 4, 18, 19, 20])
+  })
+
+  it('should handle out-of-order indexes with double-digit numbers', () => {
+    const changeValue = jest.fn((state: any, name: string, mutate: (value: any) => any) => {
+      const before = getIn(state.formState.values, name)
+      const after = mutate(before)
+      state.formState.values = setIn(state.formState.values, name, after) || {} as any
+    })
+
+    const items = Array.from({ length: 15 }, (_, i) => ({ value: i }))
+    const fields: any = {}
+    items.forEach((_, i) => {
+      fields[`items[${i}]`] = { name: `items[${i}]` }
+    })
+
+    const state: MutableState<any> = {
+      formState: { values: { items } as any },
+      fields
+    }
+
+    // Remove in random order with mixed single and double-digit indexes
+    removeBatch(['items', [10, 5, 12, 8]], state, createMockTools({ changeValue }))
+
+    const result = state.formState.values.items
+    expect(result).toHaveLength(11)
+    expect(result.map(i => i.value)).toEqual([0, 1, 2, 3, 4, 6, 7, 9, 11, 13, 14])
+  })
+})

--- a/src/removeBatch.ts
+++ b/src/removeBatch.ts
@@ -34,7 +34,7 @@ const removeBatch: Mutator<any> = (
   }
 
   const sortedIndexes: number[] = [...indexes]
-  sortedIndexes.sort()
+  sortedIndexes.sort((a, b) => a - b) // Numeric sort, not lexicographic
 
   // Remove duplicates
   for (let i = sortedIndexes.length - 1; i > 0; i -= 1) {


### PR DESCRIPTION
Fixes #97

## Problem
When `removeBatch` is called with indexes containing double-digit numbers (≥10), JavaScript's default lexicographic sort causes incorrect item removal.

### Example of the Bug:
```js
[4, 5, 6, 10, 11, 12].sort() // Returns: [10, 11, 12, 4, 5, 6] ❌
```

When you try to remove indexes 4-16 from an array of 20 items, the lexicographic sort reorders them incorrectly, causing the wrong items to be removed.

## Solution
Changed line 38 in `removeBatch.ts`:
```diff
- sortedIndexes.sort()
+ sortedIndexes.sort((a, b) => a - b) // Numeric sort, not lexicographic
```

This ensures indexes are sorted numerically:
```js
[4, 5, 6, 10, 11, 12].sort((a,b) => a-b) // Returns: [4, 5, 6, 10, 11, 12] ✅
```

## Tests
Added `removeBatch.lexicographic-bug.test.ts` with regression tests:
- ✅ Removing indexes 4-16 from array of 20 items works correctly
- ✅ Out-of-order indexes with mixed single/double-digit numbers

All 66 tests passing ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch removal operations to use numeric index ordering instead of lexicographic ordering, ensuring correct item removal behavior.

* **Tests**
  * Added comprehensive test suite for batch removal index sorting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->