### PR TITLE
fix: replace rollup-plugin-typescript2 with @rollup/plugin-typescript for rollup 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.3.0",
     "@size-limit/preset-small-lib": "^11.1.6",
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
@@ -69,7 +70,6 @@
     "prettier-eslint-cli": "^8.0.1",
     "react": "^19.1.0",
     "rollup": "^4.41.1",
-    "rollup-plugin-typescript2": "^0.36.0",
     "size-limit": "^11.1.6",
     "ts-jest": "^29.3.4",
     "typescript": "^5.8.3"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,9 +1,8 @@
 import resolve from '@rollup/plugin-node-resolve'
-import typescript from 'rollup-plugin-typescript2'
+import typescript from '@rollup/plugin-typescript'
 import commonjs from '@rollup/plugin-commonjs'
 import terser from '@rollup/plugin-terser'
 import replace from '@rollup/plugin-replace'
-import ts from 'typescript'
 
 const minify = process.env.MINIFY
 const format = process.env.FORMAT
@@ -49,18 +48,15 @@ export default {
       preferBuiltins: false
     }),
     typescript({
-      typescript: ts,
-      clean: true,
-      tsconfigOverride: {
-        compilerOptions: {
-          declaration: false,
-          declarationMap: false
-        }
-      }
+      tsconfig: './tsconfig.json',
+      declaration: false,
+      declarationMap: false,
+      noEmitOnError: true
     }),
     commonjs({ include: 'node_modules/**' }),
     umd
       ? replace({
+          preventAssignment: true,
           'process.env.NODE_ENV': JSON.stringify(
             minify ? 'production' : 'development'
           )


### PR DESCRIPTION
`rollup-plugin-typescript2` (rpt2) is incompatible with rollup 4, causing the UMD and ES builds to fail with:

```
RollupError: Expected '{', got 'interface' (Note that you need plugins to import files that are not JavaScript)
```

rpt2 was never invoked — rollup 4 changed its plugin API and rpt2 doesn't register correctly, so TypeScript files were passed through unparsed.

### Fix

- Replace `rollup-plugin-typescript2` with `@rollup/plugin-typescript` (the official rollup 4-compatible plugin)
- Add `preventAssignment: true` to `@rollup/plugin-replace` to silence the deprecation warning
- Pass `declarationMap: false` explicitly in the rollup typescript config to avoid a TS5069 error (tsconfig has `declarationMap: true` but rollup overrides `declaration: false`, causing a conflict)

### Verified

- All 4 build formats (es, cjs, umd, umd.min) now build successfully
- 76 tests passing
- All size-limit checks passing